### PR TITLE
unescape url on navigation change events.

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ class SignaturePad extends Component {
   }
 
   _onNavigationChange = (args) => {
-    this._parseMessageFromWebViewNavigationChange(args.url);
+    this._parseMessageFromWebViewNavigationChange(unescape(args.url));
   };
 
   _parseMessageFromWebViewNavigationChange = (newUrl) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-signature-pad",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "React Native wrapper around szimek's Canvas based Signature Pad",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Something has changed in WebView since React 0.21.
