### PR TITLE
remove deprecated calls to ReactNative.PropTypes and ReactNative.Comp…

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,17 @@
 'use strict';
 
-var React = require('react-native');
+var React = require('react');
+var ReactNative = require('react-native');
+
 var {
   PropTypes,
-  View,
   Component,
+} = React;
+
+var {
+  View,
   WebView,
-  } = React;
+  } = ReactNative;
 
 
 import htmlContent from './injectedHtml';


### PR DESCRIPTION
React Native 0.25 depreciated calls to ReactNative.PropTypes and ReactNative.Components, displaying warnings when these apis are still being used.

React Native 0.26 will start issuing errors when these deprecated api's are called
