### PR TITLE
Adds ability to change canvas' background color and pen color through props

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,11 +20,13 @@ import injectedApplication from './injectedJavaScript/application';
 import injectedErrorHandler from './injectedJavaScript/errorHandler';
 import injectedExecuteNativeFunction from './injectedJavaScript/executeNativeFunction';
 
-class SignaturePad extends Component {  
+class SignaturePad extends Component {
 
   static propTypes = {
     onChange: PropTypes.func,
     onError: PropTypes.func,
+    backgroundColor: PropTypes.string,
+    penColor: PropTypes.string,
     style: View.propTypes.style
   };
 
@@ -41,8 +43,9 @@ class SignaturePad extends Component {
     super(props);
     this.state = {base64DataUrl: null};
 
-    var injectedJavaScript = injectedExecuteNativeFunction + injectedErrorHandler + injectedSignaturePad + injectedApplication;
-    this.source = {html: htmlContent.replace('%SCRIPTPLACEHOLDER%', injectedJavaScript)}; //We don't use WebView's injectedJavaScript because on Android, the WebView re-injects the JavaScript upon every url change. Given that we use url changes to communicate signature changes to the React Native app, the JS is re-injected every time a stroke is drawn.
+    var injectedJavaScript = injectedExecuteNativeFunction + injectedErrorHandler + injectedSignaturePad + injectedApplication(props.penColor);
+    var html = htmlContent(injectedJavaScript, props.backgroundColor);
+    this.source = {html}; //We don't use WebView's injectedJavaScript because on Android, the WebView re-injects the JavaScript upon every url change. Given that we use url changes to communicate signature changes to the React Native app, the JS is re-injected every time a stroke is drawn.
   }
 
   _onNavigationChange = (args) => {
@@ -114,16 +117,16 @@ class SignaturePad extends Component {
   _renderLoading = (args) => {
 
   };
-  
+
   render = () => {
-    return (      
+    return (
         <WebView automaticallyAdjustContentInsets={false}
                  onNavigationStateChange={this._onNavigationChange}
                  renderError={this._renderError}
                  renderLoading={this._renderLoading}
                  source={this.source}
                  javaScriptEnabled={true}
-                 style={this.props.style}/>      
+                 style={this.props.style}/>
     )
   };
 }

--- a/index.js
+++ b/index.js
@@ -21,7 +21,6 @@ class SignaturePad extends Component {
     onError: PropTypes.func,
     style: View.propTypes.style,
     penColor: PropTypes.string,
-    exportBackgroundColor: PropTypes.string,
   };
 
   static defaultProps = {

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var ReactNative = require('react-native');
 var {
   PropTypes,
   Component,
+  StyleSheet,
 } = React;
 
 var {
@@ -25,8 +26,6 @@ class SignaturePad extends Component {
   static propTypes = {
     onChange: PropTypes.func,
     onError: PropTypes.func,
-    backgroundColor: PropTypes.string,
-    penColor: PropTypes.string,
     style: View.propTypes.style
   };
 
@@ -43,8 +42,10 @@ class SignaturePad extends Component {
     super(props);
     this.state = {base64DataUrl: null};
 
-    var injectedJavaScript = injectedExecuteNativeFunction + injectedErrorHandler + injectedSignaturePad + injectedApplication(props.penColor);
-    var html = htmlContent(injectedJavaScript, props.backgroundColor);
+    const { backgroundColor, color } = StyleSheet.flatten(props.style);
+
+    var injectedJavaScript = injectedExecuteNativeFunction + injectedErrorHandler + injectedSignaturePad + injectedApplication(color);
+    var html = htmlContent(injectedJavaScript, backgroundColor);
     this.source = {html}; //We don't use WebView's injectedJavaScript because on Android, the WebView re-injects the JavaScript upon every url change. Given that we use url changes to communicate signature changes to the React Native app, the JS is re-injected every time a stroke is drawn.
   }
 

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ class SignaturePad extends Component {
     onError: PropTypes.func,
     style: View.propTypes.style,
     penColor: PropTypes.string,
+    exportBackgroundColor: PropTypes.string,
   };
 
   static defaultProps = {
@@ -36,8 +37,11 @@ class SignaturePad extends Component {
     super(props);
     this.state = {base64DataUrl: null};
     const { backgroundColor } = StyleSheet.flatten(props.style);
-    var injectedJavaScript = injectedExecuteNativeFunction + injectedErrorHandler + injectedSignaturePad + injectedApplication(props.penColor);
-    var html = htmlContent(injectedJavaScript, backgroundColor);
+    var injectedJavaScript = injectedExecuteNativeFunction
+      + injectedErrorHandler
+      + injectedSignaturePad
+      + injectedApplication(props.penColor, backgroundColor);
+    var html = htmlContent(injectedJavaScript);
     this.source = {html}; //We don't use WebView's injectedJavaScript because on Android, the WebView re-injects the JavaScript upon every url change. Given that we use url changes to communicate signature changes to the React Native app, the JS is re-injected every time a stroke is drawn.
   }
 

--- a/index.js
+++ b/index.js
@@ -6,13 +6,13 @@ var ReactNative = require('react-native');
 var {
   PropTypes,
   Component,
-  StyleSheet,
 } = React;
 
 var {
   View,
   WebView,
-  } = ReactNative;
+  StyleSheet,
+} = ReactNative;
 
 
 import htmlContent from './injectedHtml';
@@ -26,7 +26,8 @@ class SignaturePad extends Component {
   static propTypes = {
     onChange: PropTypes.func,
     onError: PropTypes.func,
-    style: View.propTypes.style
+    style: View.propTypes.style,
+    penColor: PropTypes.string,
   };
 
   static defaultProps = {
@@ -41,10 +42,8 @@ class SignaturePad extends Component {
   constructor(props) {
     super(props);
     this.state = {base64DataUrl: null};
-
-    const { backgroundColor, color } = StyleSheet.flatten(props.style);
-
-    var injectedJavaScript = injectedExecuteNativeFunction + injectedErrorHandler + injectedSignaturePad + injectedApplication(color);
+    const { backgroundColor } = StyleSheet.flatten(props.style);
+    var injectedJavaScript = injectedExecuteNativeFunction + injectedErrorHandler + injectedSignaturePad + injectedApplication(props.penColor);
     var html = htmlContent(injectedJavaScript, backgroundColor);
     this.source = {html}; //We don't use WebView's injectedJavaScript because on Android, the WebView re-injects the JavaScript upon every url change. Given that we use url changes to communicate signature changes to the React Native app, the JS is re-injected every time a stroke is drawn.
   }

--- a/injectedHtml/index.js
+++ b/injectedHtml/index.js
@@ -1,4 +1,4 @@
-var content = (script, backgroundColor) =>
+var content = script =>
   `<html>
     <style>
     *
@@ -19,7 +19,7 @@ var content = (script, backgroundColor) =>
 
     </style>
     <body>
-      <canvas style="background-color: ${backgroundColor || 'rgb(255, 255, 255)'}; margin-left: 0; margin-top: 0;"></canvas>
+      <canvas style="margin-left: 0; margin-top: 0;"></canvas>
       <script>
         ${script}
       </script>

--- a/injectedHtml/index.js
+++ b/injectedHtml/index.js
@@ -1,28 +1,29 @@
-var content = `<html>
-  <style>
-  *
-  {margin:0;padding:0;}
+var content = (script, backgroundColor) =>
+  `<html>
+    <style>
+    *
+    {margin:0;padding:0;}
 
-  canvas
-  {
-    position:absolute;transform:translateZ(0);
-    /* In case the React Transformation is not performant, we'll fall back to this one
+    canvas
+    {
+      position:absolute;transform:translateZ(0);
+      /* In case the React Transformation is not performant, we'll fall back to this one
 
-    transform-origin:left top;
-    -ms-transform-origin:left top;
-    -webkit-transform-origin:left top;
-    transform:rotate(-90deg) translate(-100%, 0px);
-    -ms-transform:rotate(-90deg)  translate(-100%, 0px);
-    -webkit-transform:rotate(-90deg)  translate(-100%, 0px);*/
-  }
+      transform-origin:left top;
+      -ms-transform-origin:left top;
+      -webkit-transform-origin:left top;
+      transform:rotate(-90deg) translate(-100%, 0px);
+      -ms-transform:rotate(-90deg)  translate(-100%, 0px);
+      -webkit-transform:rotate(-90deg)  translate(-100%, 0px);*/
+    }
 
-  </style>
-  <body>
-    <canvas style="background-color: rgb(255,255,255); margin-left: 0; margin-top: 0;"></canvas>
-    <script>
-      %SCRIPTPLACEHOLDER%
-    </script>
-  </body>
-</html>`;
+    </style>
+    <body>
+      <canvas style="background-color: ${backgroundColor || 'rgb(255, 255, 255)'}; margin-left: 0; margin-top: 0;"></canvas>
+      <script>
+        ${script}
+      </script>
+    </body>
+  </html>`;
 
 export default content;

--- a/injectedJavaScript/application.js
+++ b/injectedJavaScript/application.js
@@ -1,4 +1,4 @@
-var content = penColor => `
+var content = (penColor, backgroundColor) => `
 
   var showSignaturePad = function (signaturePadCanvas, bodyWidth, bodyHeight) {
     /*We're rotating by 90% -> Flip X and Y*/
@@ -24,6 +24,7 @@ var content = penColor => `
     var enableSignaturePadFunctionality = function () {
       var signaturePad = new SignaturePad(signaturePadCanvas, {
         penColor: '${penColor || 'black'}',
+        backgroundColor: '${backgroundColor || 'white'}',
         onEnd: function() { finishedStroke(signaturePad.toDataURL()); }
       });
       /* signaturePad.translateMouseCoordinates = function (point) {

--- a/injectedJavaScript/application.js
+++ b/injectedJavaScript/application.js
@@ -23,7 +23,7 @@ var content = penColor => `
 
     var enableSignaturePadFunctionality = function () {
       var signaturePad = new SignaturePad(signaturePadCanvas, {
-        penColor: '${penColor}',
+        penColor: '${penColor || 'black'}',
         onEnd: function() { finishedStroke(signaturePad.toDataURL()); }
       });
       /* signaturePad.translateMouseCoordinates = function (point) {

--- a/injectedJavaScript/application.js
+++ b/injectedJavaScript/application.js
@@ -1,4 +1,4 @@
-var content = `
+var content = penColor => `
 
   var showSignaturePad = function (signaturePadCanvas, bodyWidth, bodyHeight) {
     /*We're rotating by 90% -> Flip X and Y*/
@@ -22,7 +22,10 @@ var content = `
     };
 
     var enableSignaturePadFunctionality = function () {
-      var signaturePad = new SignaturePad(signaturePadCanvas, {onEnd: function() { finishedStroke(signaturePad.toDataURL()); }});
+      var signaturePad = new SignaturePad(signaturePadCanvas, {
+        penColor: '${penColor}',
+        onEnd: function() { finishedStroke(signaturePad.toDataURL()); }
+      });
       /* signaturePad.translateMouseCoordinates = function (point) {
         var translatedY = point.x;
         var translatedX = width - point.y;
@@ -46,7 +49,7 @@ var content = `
   if(!bodyHeight) {
     bodyHeight = window.innerHeight;
   }
-  
+
   var canvasElement = document.querySelector('canvas');
   showSignaturePad(canvasElement, bodyWidth, bodyHeight);
 `;


### PR DESCRIPTION
Adds props to SignaturePad component for setting the backgroundColor and penColor.

Example:

```
<SignaturePad
  backgroundColor="#ba5a55"
  penColor="#0054e3"
  onChange={this.onChange}
/>
```

Renders:
![screen shot 2016-06-10 at 9 36 18 am](https://cloud.githubusercontent.com/assets/4681530/15966183/04d8e900-2ef0-11e6-927d-a639aa199cd6.png)

The default fall back colors are still black and white:

```
<SignaturePad
  onChange={this.onChange}
/>
```

Renders:
![screen shot 2016-06-10 at 9 44 51 am](https://cloud.githubusercontent.com/assets/4681530/15966201/1ac87604-2ef0-11e6-9306-2e2d904de613.png)

Unfortunately, you cannot set the backgroundColor through the style prop because we cannot guarantee that it will be a string. The style prop, if created as a Stylesheet, will be passed as number and we are unable to see the `backgroundColor` value.
