### PR TITLE
Updated import statements

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,17 +1,10 @@
 'use strict';
 
-var React = require('react');
-var ReactNative = require('react-native');
-
-var {
-  PropTypes,
-  Component,
-} = React;
-
-var {
+import React, { Component, PropTypes } from 'react';
+import {
   View,
   WebView,
-  } = ReactNative;
+  } from 'react-native';
 
 
 import htmlContent from './injectedHtml';


### PR DESCRIPTION
Imports in index.js now refelect latest react-native appropiate syntax.

See https://github.com/facebook/react-native/releases/tag/v0.25.1

---

Requiring React API from react-native is now deprecated - 2eafcd4 0b534d1

Instead of:

``` Javascript
import React, { Component, View } from 'react-native';
```

you should now:

``` Javascript
import React, { Component } from 'react';
import { View } from 'react-native';  
```
