### PR TITLE
This is intended to fix the "Not allowed to navigate top frame to data URL" error reported from newer versions of Chromium.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ React Native wrapper around @[szimek's](https://github.com/szimek) HTML5 Canvas 
 
 - Supports Android and iOS
 - Pure JavaScript implementation with no native dependencies
-- Tested with RN 0.20
+- Tested with RN 0.37
 - Can easily be rotated using the "transform" style
 - Generates a base64 encoded png image of the signature
 

--- a/index.js
+++ b/index.js
@@ -45,58 +45,22 @@ class SignaturePad extends Component {
     this.source = {html}; //We don't use WebView's injectedJavaScript because on Android, the WebView re-injects the JavaScript upon every url change. Given that we use url changes to communicate signature changes to the React Native app, the JS is re-injected every time a stroke is drawn.
   }
 
-  _onNavigationChange = (args) => {
-    this._parseMessageFromWebViewNavigationChange(unescape(args.url));
-  };
-
-  _parseMessageFromWebViewNavigationChange = (newUrl) => {
-    //Example input:
-    //applewebdata://4985ECDA-4C2B-4E37-87ED-0070D14EB985#executeFunction=jsError&arguments=%7B%22message%22:%22ReferenceError:%20Can't%20find%20variable:%20WHADDUP%22,%22url%22:%22applewebdata://4985ECDA-4C2B-4E37-87ED-0070D14EB985%22,%22line%22:340,%22column%22:10%7D"
-    //All parameters to the native world are passed via a hash url where every parameter is passed as &[ParameterName]<-[Content]&
-    var hashUrlIndex = newUrl.lastIndexOf('#');
-    if(hashUrlIndex === -1) {
-      return;
-    }
-
-    var hashUrl = newUrl.substring(hashUrlIndex);
-    hashUrl = decodeURIComponent(hashUrl);
-    var regexFindAllSubmittedParameters = /&(.*?)&/g;
-
-    var parameters = {};
-    var parameterMatch = regexFindAllSubmittedParameters.exec(hashUrl);
-    if(!parameterMatch) {
-      return;
-    }
-
-    while(parameterMatch) {
-      var parameterPair = parameterMatch[1]; //For example executeFunction=jsError or arguments=...
-
-      var parameterPairSplit = parameterPair.split('<-');
-      if(parameterPairSplit.length === 2) {
-        parameters[parameterPairSplit[0]] = parameterPairSplit[1];
-      }
-
-      parameterMatch = regexFindAllSubmittedParameters.exec(hashUrl);
-    }
-
-    if(!this._attemptToExecuteNativeFunctionFromWebViewMessage(parameters)) {
-      logger.warn({parameters, hashUrl}, 'Received an unknown set of parameters from WebView');
-    }
-  };
-
   _attemptToExecuteNativeFunctionFromWebViewMessage = (message) => {
     if(message.executeFunction && message.arguments) {
-      var parsedArguments = JSON.parse(message.arguments);
-
       var referencedFunction = this['_bridged_' + message.executeFunction];
       if(typeof(referencedFunction) === 'function') {
-        referencedFunction.apply(this, [parsedArguments]);
+        referencedFunction.apply(this, [message.arguments]);
         return true;
       }
     }
 
     return false;
   };
+
+  _onMessage = (e) => {
+    const message = JSON.parse(e.nativeEvent.data);
+    this._attemptToExecuteNativeFunctionFromWebViewMessage(message)
+  }
 
   _bridged_jsError = (args) => {
     this.props.onError({details: args});
@@ -121,6 +85,7 @@ class SignaturePad extends Component {
                  onNavigationStateChange={this._onNavigationChange}
                  renderError={this._renderError}
                  renderLoading={this._renderLoading}
+                 onMessage={this._onMessage}
                  source={this.source}
                  javaScriptEnabled={true}
                  style={this.props.style}/>

--- a/injectedJavaScript/executeNativeFunction.js
+++ b/injectedJavaScript/executeNativeFunction.js
@@ -1,6 +1,6 @@
 var content = `
   function executeNativeFunction(fnName, args) {
-    window.location.hash = '&executeFunction<-' + fnName + '&' + '&arguments<-' + JSON.stringify(args) + '&';
+    window.postMessage(JSON.stringify({ executeFunction: fnName, arguments: args }));
   }
 `;
 


### PR DESCRIPTION
When using react-native on Android, the react-native-signature-pad suddenly stopped working and began reporting "Not allowed to navigate top frame to data URL" in the Android monitor console. Presumably, this was due to a chromium update. This PR is intended to work around that problem by using the postMessage() feature supported by RN 0.37.
