### PR TITLE
fix: keep signature drawing inside canvas

### DIFF
--- a/injectedJavaScript/signaturePad.js
+++ b/injectedJavaScript/signaturePad.js
@@ -153,7 +153,7 @@ var content = `var SignaturePad = (function (document) {
       var pointOutOfCanvas = (x < 0 || y < 0 || x > rect.width || y > rect.height); // checking if point is outside of canvas
       if (pointOutOfCanvas) {
         if (!self.pointWasOutOfCanvas) {
-          // if the previous was inside of canvas and the new point it is outside
+          // if the previous point was inside of canvas and the new point is outside
           // call onEnd to capture the signature
           self.onEnd();
         }

--- a/injectedJavaScript/signaturePad.js
+++ b/injectedJavaScript/signaturePad.js
@@ -169,10 +169,12 @@ var content = `var SignaturePad = (function (document) {
 
   SignaturePad.prototype._createPoint = function (event) {
     var rect = this._canvas.getBoundingClientRect();
-    var point = new Point(
-      event.clientX - rect.left,
-      event.clientY - rect.top
-    );
+    var x = event.clientX - rect.left;
+    var y = event.clientY - rect.top;
+    // if point is outside of the canvas, reset x,y back to 0
+    x = x < 0 ? 0 : Math.min(x, rect.width);
+    y = y < 0 ? 0 : Math.min(y, rect.height);
+    var point = new Point(x, y);
 
     if(this.translateMouseCoordinates)
       this.translateMouseCoordinates(point);


### PR DESCRIPTION
Edit:

Actually I have found a better solution, the commit before didn't solve the issue that when you move your finger outside of the canvas and release, the signature is not captured. The new commit capture the signature when this happens:

Before fix:

![signature_pad_before_fix](https://user-images.githubusercontent.com/3773090/38342632-f6be5e0c-38c2-11e8-9f18-9c5c5ef7d467.gif)


After fix:

![signature_pad_after_fix](https://user-images.githubusercontent.com/3773090/38342635-fab5c8d8-38c2-11e8-8212-a405584d4740.gif)

