### PR TITLE
Zoom in/out on double tap, viewport, initial-scale=1.0

### DIFF
--- a/injectedHtml/index.js
+++ b/injectedHtml/index.js
@@ -1,5 +1,6 @@
 var content = script =>
   `<html>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <style>
     *
     {margin:0;padding:0;}


### PR DESCRIPTION
Salutations!! Great job..
I noticed that the html that is loaded in the WebView can zoom in and out with a double tap.
Adding something like this, will disable this behaviour:
```html
<meta name="viewport" content="width=device-width, initial-scale=1.0">
```
Cheers
:))